### PR TITLE
Rails 3: rails g scaffold doesn't work

### DIFF
--- a/lib/enumerated_attribute/rails_helpers.rb
+++ b/lib/enumerated_attribute/rails_helpers.rb
@@ -36,7 +36,6 @@ end
 #ARGV is used by generators -- if it contains one of these generator commands - add enumeration support
 #unless ((ARGV || []) & ["scaffold", "rspec_scaffold", "nifty_scaffold"]).empty?
 if ((ARGV || []).any?{|o| o =~ /scaffold/ })
-	require 'rails_generator' rescue nil
   begin
     require 'rails/generators'
     require 'rails/generators/generated_attribute'
@@ -45,7 +44,7 @@ if ((ARGV || []).any?{|o| o =~ /scaffold/ })
   end
 
 	module Rails
-		module Generator
+		module Generators
 			class GeneratedAttribute
 				def field_type_with_enumerated_attribute
 					return (@field_type = :enum_select) if type == :enum


### PR DESCRIPTION
In latest Rails 3 (release candidate) when 'rails g scaffold' is called I get the following error:

```
Corsica:enumtest $ rails g scaffold
/Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute/rails_helpers.rb:26:in `require': no such file to load -- rails_generator (LoadError)
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute/rails_helpers.rb:26
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute/attribute.rb:7:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute/attribute.rb:7
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute.rb:3:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/bundler/gems/enumerated_attribute-c5e2944/lib/enumerated_attribute.rb:3
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:64:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:64:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:62:in `each'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:62:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:51:in `each'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler/runtime.rb:51:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/bundler-1.0.0.rc.1/lib/bundler.rb:109:in `require'
from /Users/basti/dev/rails3/enumtest/config/application.rb:7
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/railties-3.0.0.rc/lib/rails/commands.rb:15:in `require'
from /Users/basti/.rvm/gems/ruby-1.8.7-p174/gems/railties-3.0.0.rc/lib/rails/commands.rb:15
from script/rails:6:in `require'
from script/rails:6
```
