### PR TITLE
fix deprecation warnings with 3.1.1

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -557,9 +557,9 @@ ActiveRecord's write_attribute and read_attribute methods do not support symbols
 
 == Testing
 
-The plugin uses RSpec and Webrat for testing.  Make sure you have the RSpec gem installed:
+The plugin uses jeweler, RSpec, and Webrat for testing.  Make sure you have these gems installed:
 
-  gem install rspec webrat
+  gem install rspec webrat jeweler
   
 To test the plugin for regular ruby objects, run:
 

--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -18,7 +18,7 @@ module EnumeratedAttribute
 					end
 				end
 			end
-			
+
 			def write_enumerated_attribute(name, val)
 				name = name.to_s
 				return write_attribute(name, val) unless self.class.has_enumerated_attribute?(name)
@@ -29,7 +29,7 @@ module EnumeratedAttribute
 				write_attribute(name, val_str)
 				val_sym
 			end
-			
+
 			def read_enumerated_attribute(name)
 				name = name.to_s
 				#if not enumerated - let active record handle it
@@ -42,17 +42,21 @@ module EnumeratedAttribute
 				val = val.to_sym if !!val
 				val
 			end
-			
+
 			def attributes=(attrs, guard_protected_attributes=true)
 				return if attrs.nil?
-				#check the attributes then turn them over 
+				#check the attributes then turn them over
 				attrs.each do |k, v|
 					attrs[k] = v.to_s if self.class.has_enumerated_attribute?(k)
 				end
-				
-				super
+
+				if guard_protected_attributes
+                                  super(attrs) #prevents deprecation warnings for rails 3.1.1
+                                else
+                                  super(attrs, guard_protected_attributes)
+                                end
 			end
-			
+
 			def attributes
 				atts = super
 				atts.each do |k,v|
@@ -62,23 +66,23 @@ module EnumeratedAttribute
 				end
 				atts
 			end
-			
+
       def [](attr_name); read_enumerated_attribute(attr_name); end
       def []=(attr_name, value); write_enumerated_attribute(attr_name, value); end
-			
+
 			private
-						
+
 			def attribute=(attr_name, value); write_enumerated_attribute(attr_name, value); end
-									
+
 			module ClassMethods
 				private
-				
+
 				def construct_attributes_from_arguments(attribute_names, arguments)
           attributes = {}
           attribute_names.each_with_index{|name, idx| attributes[name] = has_enumerated_attribute?(name) ? arguments[idx].to_s : arguments[idx]}
           attributes
 				end
-				
+
 				def instantiate(record)
 					object = super(record)
 					self.enumerated_attributes.each do |k,v|
@@ -88,7 +92,7 @@ module EnumeratedAttribute
 					end
 					object
 				end
-				
+
 				def define_enumerated_attribute_new_method
 					class_eval do
 						class << self
@@ -113,6 +117,6 @@ module EnumeratedAttribute
           end
 				end
 			end
-		end	
+		end
 	end
 end


### PR DESCRIPTION
I was getting deprecation warnings in my test suite when calling attributes= on my models... they are removing the guard_protected_attributes argument soon. this prepares for that, and fixes the deprecation warning, while maintaining backwards compatibility for now.
