### PR TITLE
attributes= raises exception with rails 3.2

### DIFF
--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -43,18 +43,14 @@ module EnumeratedAttribute
 				val
 			end
 
-			def attributes=(attrs, guard_protected_attributes=true)
+			def attributes=(attrs)
 				return if attrs.nil?
 				#check the attributes then turn them over
 				attrs.each do |k, v|
 					attrs[k] = v.to_s if self.class.has_enumerated_attribute?(k)
 				end
 
-				if guard_protected_attributes
-                                  super(attrs) #prevents deprecation warnings for rails 3.1.1
-                                else
-                                  super(attrs, guard_protected_attributes)
-                                end
+				super
 			end
 
 			def attributes


### PR DESCRIPTION
The method has been modified to accept a single hash argument as of 3.2

See:
http://apidock.com/rails/ActiveRecord/Base/attributes%3D
http://apidock.com/rails/ActiveRecord/AttributeAssignment/attributes%3D
