### PR TITLE
Updated Formtastic example to work with Formtastic 2

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -502,7 +502,24 @@ Second, do not forget to add the +enum_attr+ macro to the generated model and mi
   
 === Formtastic integration
 
-You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with an initializer:
+You can make Formtastic generate a select with the enum value filled in. 
+
+For Formtastic 2, define a custom input class:
+
+    require 'formtastic'
+
+    class EnumInput < Formtastic::Inputs::SelectInput
+      def raw_collection
+        @raw_collection ||= collection_from_options || collection_from_enum 
+      end
+
+      def collection_from_enum
+        @object.enums(method.to_sym).try(:select_options) || []
+        choices = enum ? enum.select_options : []
+      end
+    end
+
+For Formtastic 1, define a custom helper:
 
     require 'formtastic'
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -502,7 +502,7 @@ Second, do not forget to add the +enum_attr+ macro to the generated model and mi
   
 === Formtastic integration
 
-You can make Formtastic generate a select with the enum value filled in. 
+You can make Formtastic generate a select with the enum values filled in automatically. 
 
 For Formtastic 2, define a custom input class:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -515,7 +515,6 @@ For Formtastic 2, define a custom input class:
 
       def collection_from_enum
         @object.enums(method.to_sym).try(:select_options) || []
-        choices = enum ? enum.select_options : []
       end
     end
 


### PR DESCRIPTION
Hi,

Formtastic 2 deprecated the `enum_input` helper described in the readme.

Here's an updated version of the code.

Leonid.
