### PR TITLE
read_enumerated_attribute fix for integer-based activerecord fields

### DIFF
--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -24,7 +24,7 @@ module EnumeratedAttribute
 				return write_attribute(name, val) unless self.class.has_enumerated_attribute?(name)
 				val = nil if val == ''
 				val_str = val.to_s if val
-				val_sym = val.to_sym if val
+				val_sym = val.to_s.to_sym if val
 				return instance_variable_set('@'+name, val_sym) unless self.has_attribute?(name)
 				write_attribute(name, val_str)
 				val_sym
@@ -57,7 +57,7 @@ module EnumeratedAttribute
 				atts = super
 				atts.each do |k,v|
 					if self.class.has_enumerated_attribute?(k)
-						atts[k] = v.to_sym if v
+						atts[k] = v.to_s.to_sym if v
 					end
 				end
 				atts

--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -39,7 +39,7 @@ module EnumeratedAttribute
 				return instance_variable_get('@'+name) unless self.has_attribute?(name)
 				#this is an enumerated active record attribute
 				val = read_attribute(name)
-				val = val.to_sym if !!val
+				val = val.to_s.to_sym if !!val
 				val
 			end
 


### PR DESCRIPTION
read_enumerated_attribute wasn't handling integer-based activerecord fields
