### PR TITLE
Update README to latest formtastic API

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -507,19 +507,21 @@ You can display the select input in a Formtastic form with a little monkey patch
     require 'formtastic'
 
     module Formtastic #:nodoc:
-      class SemanticFormBuilder #:nodoc:
-        def enum_input(method, options)
-          unless options[:collection]
-            enum = @object.enums(method.to_sym)
-            choices = enum ? enum.select_options : []
-            options[:collection] = choices
+      module Inputs #:nodoc:
+        class EnumInput < SelectInput #:nodoc:
+          def to_html
+            unless options[:collection]
+              enum = @object.enums(method.to_sym)
+              choices = enum ? enum.select_options : []
+              options[:collection] = choices
+            end
+            if (value = @object.__send__(method.to_sym))
+              options[:selected] ||= value.to_s
+            else
+              options[:include_blank] ||= true
+            end
+            super
           end
-          if (value = @object.__send__(method.to_sym))
-            options[:selected] ||= value.to_s
-          else
-            options[:include_blank] ||= true
-          end
-          select_input(method, options)
         end
       end
     end


### PR DESCRIPTION
The initializer in the README to monkey patch Formtastic doesn't work, since the API has changed.

The patch fixes the initializer for the latest API.
