### PR TITLE
Localisation

### DIFF
--- a/lib/enumerated_attribute/attribute/attribute_descriptor.rb
+++ b/lib/enumerated_attribute/attribute/attribute_descriptor.rb
@@ -40,11 +40,7 @@ module EnumeratedAttribute
 				@labels_hash
 			end
 			def select_options
-				if @options.key?(:localize) && @options[:localize]
-					@select_options ||= self.map{|e| [I18n.t(@labels_hash[e]), e.to_s]}
-				else
-					@select_options ||= self.map{|e| [@labels_hash[e], e.to_s]}
-				end
+				@select_options ||= self.map{|e| [label(e), e.to_s]}
 			end
 			def set_label(enum_value, label_string)
 				reset_labels

--- a/lib/enumerated_attribute/attribute/attribute_descriptor.rb
+++ b/lib/enumerated_attribute/attribute/attribute_descriptor.rb
@@ -9,7 +9,11 @@ module EnumeratedAttribute
 				super enums
 				@name = name
 				@options = opts
-				@labels_hash = Hash[*self.collect{|e| [e, e.to_s.gsub(/_/, ' ').squeeze(' ').capitalize]}.flatten]
+				if @options.key?(:localize) && @options[:localize]
+					@labels_hash = Hash[*self.collect{|e| [e, e.to_s]}.flatten]
+				else
+					@labels_hash = Hash[*self.collect{|e| [e, e.to_s.gsub(/_/, ' ').squeeze(' ').capitalize]}.flatten]
+				end
 			end
 			
 			def allows_nil?
@@ -23,18 +27,25 @@ module EnumeratedAttribute
 				self
 			end
 			def label(value)
-				@labels_hash[value]
+				if @options.key?(:localize) && @options[:localize]
+					I18n.t(@labels_hash[value])
+				else
+					@labels_hash[value]
+				end
 			end
 			def labels
-				@labels_array ||= self.map{|e| @labels_hash[e]}
+				@labels_array ||= self.map{|e| label(e)}
 			end
 			def hash
 				@labels_hash
 			end
 			def select_options
-				@select_options ||= self.map{|e| [@labels_hash[e], e.to_s]}
+				if @options.key?(:localize) && @options[:localize]
+					@select_options ||= self.map{|e| [I18n.t(@labels_hash[e]), e.to_s]}
+				else
+					@select_options ||= self.map{|e| [@labels_hash[e], e.to_s]}
+				end
 			end
-			
 			def set_label(enum_value, label_string)
 				reset_labels
 				@labels_hash[enum_value.to_sym] = label_string


### PR DESCRIPTION
In my project, I'm using enumerated_attribute, but I need to display the options in the right language.
I added a new options ":localize", and if it's set to true, then the labels are translated.
Example: 

``` ruby
enum_attr :currency, %w(en ja), :init => I18n.locale, :localize => true do 
  label :en => "dollar"
  label :ja => "yen"
end
```

Then if the website is in Japanese I will see 円 and if it is in English I will see ¥.
