### PR TITLE
Add helper for change method in rails migrations

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -504,25 +504,11 @@ Second, do not forget to add the +enum_attr+ macro to the generated model and mi
 
 You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with a file in +app/inputs/enum_input.rb+:
 
-    require 'formtastic'
-
-    module Formtastic #:nodoc:
-      module Inputs #:nodoc:
-        class EnumInput < SelectInput #:nodoc:
-          def to_html
-            unless options[:collection]
-              enum = @object.enums(method.to_sym)
-              choices = enum ? enum.select_options : []
-              options[:collection] = choices
-            end
-            if (value = @object.__send__(method.to_sym))
-              options[:selected] ||= value.to_s
-            else
-              options[:include_blank] ||= true
-            end
-            super
-          end
-        end
+    class EnumInput < Formtastic::Inputs::SelectInput # or RadioInput
+      def raw_collection
+        enum = @object.enums(method.to_sym)
+        choices = enum ? enum.select_options : []
+        @raw_collection ||= (collection_from_options || choices)
       end
     end
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -502,7 +502,7 @@ Second, do not forget to add the +enum_attr+ macro to the generated model and mi
   
 === Formtastic integration
 
-You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with an initializer:
+You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with a file in @app/inputs/enum_input.rb@:
 
     require 'formtastic'
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -502,7 +502,7 @@ Second, do not forget to add the +enum_attr+ macro to the generated model and mi
   
 === Formtastic integration
 
-You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with a file in @app/inputs/enum_input.rb@:
+You can display the select input in a Formtastic form with a little monkey patching. First, extend Formtastic with a file in +app/inputs/enum_input.rb+:
 
     require 'formtastic'
 

--- a/lib/enumerated_attribute/rails_helpers.rb
+++ b/lib/enumerated_attribute/rails_helpers.rb
@@ -36,6 +36,12 @@ if defined?(ActiveRecord)
         end
       end
     end
+    class Migration
+      def add_column(table, name, type, options = {})
+        type = 'string' if type.to_s == 'enum'
+        method_missing(:add_column, table, name, type, options)
+      end
+    end
   end
 end
 

--- a/lib/enumerated_attribute/rails_helpers.rb
+++ b/lib/enumerated_attribute/rails_helpers.rb
@@ -1,42 +1,42 @@
 require 'active_record/connection_adapters/abstract/schema_definitions'
 
 if defined?(ActiveRecord)
-	module ActiveRecord
-		module ConnectionAdapters
-			class TableDefinition
-				def column_with_enumerated_attribute(name, type, options = {})
-					type = 'string' if type.to_s == 'enum'
-					column_without_enumerated_attribute(name, type, options)
-				end
-				safe_alias_method_chain :column, :enumerated_attribute
-				
-				def enum(*args)
-					options = args.extract_options!                                      
-					column_names = args                                                   
-					column_names.each { |name| column(name, 'string', options) }  
-				end
-			end
-			class Table
-				def column_with_enumerated_attribute(name, type, options = {})
-					type = 'string' if type.to_s == 'enum'
-					column_without_enumerated_attribute(name, type, options)
-				end
-				safe_alias_method_chain :column, :enumerated_attribute
+  module ActiveRecord
+    module ConnectionAdapters
+      class TableDefinition
+        def column_with_enumerated_attribute(name, type, options = {})
+          type = 'string' if type.to_s == 'enum'
+          column_without_enumerated_attribute(name, type, options)
+        end
+        safe_alias_method_chain :column, :enumerated_attribute
 
-				def change_with_enumerated_attribute(name, type, options = {})
-					type = 'string' if type.to_s == 'enum'
-					change_without_enumerated_attribute(name, type, options)
-				end
-				safe_alias_method_chain :change, :enumerated_attribute
-				
-				def enum(*args)
-					options = args.extract_options!                                      
-					column_names = args                                                   
-					column_names.each { |name| column(name, 'string', options) }  
-				end
-			end
-		end
-	end
+        def enum(*args)
+          options = args.extract_options!
+          column_names = args
+          column_names.each { |name| column(name, 'string', options) }
+        end
+      end
+      class Table
+        def column_with_enumerated_attribute(name, type, options = {})
+          type = 'string' if type.to_s == 'enum'
+          column_without_enumerated_attribute(name, type, options)
+        end
+        safe_alias_method_chain :column, :enumerated_attribute
+
+        def change_with_enumerated_attribute(name, type, options = {})
+          type = 'string' if type.to_s == 'enum'
+          change_without_enumerated_attribute(name, type, options)
+        end
+        safe_alias_method_chain :change, :enumerated_attribute
+
+        def enum(*args)
+          options = args.extract_options!
+          column_names = args
+          column_names.each { |name| column(name, 'string', options) }
+        end
+      end
+    end
+  end
 end
 
 #ARGV is used by generators -- if it contains one of these generator commands - add enumeration support
@@ -49,70 +49,70 @@ if ((ARGV || []).any?{|o| o =~ /scaffold/ })
   rescue Exception => ex
   end
 
-	module Rails
-		module Generators
-			class GeneratedAttribute
-				def field_type_with_enumerated_attribute
-					return (@field_type = :enum_select) if type == :enum
-					field_type_without_enumerated_attribute
-				end
-				alias_method_chain :field_type, :enumerated_attribute
-			end
-		end
-	end
+  module Rails
+    module Generators
+      class GeneratedAttribute
+        def field_type_with_enumerated_attribute
+          return (@field_type = :enum_select) if type == :enum
+          field_type_without_enumerated_attribute
+        end
+        alias_method_chain :field_type, :enumerated_attribute
+      end
+    end
+  end
 end
 
 if defined?(ActionView::Base)
-	module ActionView
-		module Helpers
-		
-			#form_options_helper.rb
-			module FormOptionsHelper
-				#def select
-				def enum_select(object, method, options={}, html_options={})
-					InstanceTag.new(object, method, self, options.delete(:object)).to_enum_select_tag(options, html_options)
-				end
-			end
-			
-			class InstanceTag
-				def to_enum_select_tag(options, html_options={})
-					choices = []
-					if self.object.respond_to?(:enums)
-						enums = self.object.enums(method_name.to_sym)
-						choices = enums ? enums.select_options : []
-						if (value = self.object.__send__(method_name.to_sym))
-							options[:selected] ||= value.to_s
-						else
+  module ActionView
+    module Helpers
+
+      #form_options_helper.rb
+      module FormOptionsHelper
+        #def select
+        def enum_select(object, method, options={}, html_options={})
+          InstanceTag.new(object, method, self, options.delete(:object)).to_enum_select_tag(options, html_options)
+        end
+      end
+
+      class InstanceTag
+        def to_enum_select_tag(options, html_options={})
+          choices = []
+          if self.object.respond_to?(:enums)
+            enums = self.object.enums(method_name.to_sym)
+            choices = enums ? enums.select_options : []
+            if (value = self.object.__send__(method_name.to_sym))
+              options[:selected] ||= value.to_s
+            else
               options[:include_blank] = enums.allows_nil? if options[:include_blank].nil?
-						end
-					end
-					to_select_tag(choices, options, html_options)
-				end
-				
-				#initialize record_name, method, self
-				if respond_to?(:to_tag)
-  				def to_tag_with_enumerated_attribute(options={})
-  					#look for an enum
-  					if (column_type == :string && 
-  						self.object.class.respond_to?(:has_enumerated_attribute?) &&
-  						self.object.class.has_enumerated_attribute?(method_name.to_sym)) 
-  						to_enum_select_tag(options)
-  					else
-  						to_tag_without_enumerated_attribute(options)
-  					end
-  				end
-  				alias_method_chain :to_tag, :enumerated_attribute
-				end
-			end
-			
-			class FormBuilder
-				def enum_select(method, options={}, html_options={})
-					@template.enum_select(@object_name, method, objectify_options(options), @default_options.merge(html_options))
-				end
-			end
-			
-		end
-	end
+            end
+          end
+          to_select_tag(choices, options, html_options)
+        end
+
+        #initialize record_name, method, self
+        if respond_to?(:to_tag)
+          def to_tag_with_enumerated_attribute(options={})
+            #look for an enum
+            if (column_type == :string &&
+              self.object.class.respond_to?(:has_enumerated_attribute?) &&
+              self.object.class.has_enumerated_attribute?(method_name.to_sym))
+              to_enum_select_tag(options)
+            else
+              to_tag_without_enumerated_attribute(options)
+            end
+          end
+          alias_method_chain :to_tag, :enumerated_attribute
+        end
+      end
+
+      class FormBuilder
+        def enum_select(method, options={}, html_options={})
+          @template.enum_select(@object_name, method, objectify_options(options), @default_options.merge(html_options))
+        end
+      end
+
+    end
+  end
 end
 
 

--- a/lib/enumerated_attribute/rails_helpers.rb
+++ b/lib/enumerated_attribute/rails_helpers.rb
@@ -41,6 +41,10 @@ if defined?(ActiveRecord)
         type = 'string' if type.to_s == 'enum'
         method_missing(:add_column, table, name, type, options)
       end
+      def change_column(table, name, type, options = {})
+        type = 'string' if type.to_s == 'enum'
+        method_missing(:change_column, table, name, type, options)
+      end
     end
   end
 end

--- a/lib/enumerated_attribute/rails_helpers.rb
+++ b/lib/enumerated_attribute/rails_helpers.rb
@@ -22,6 +22,12 @@ if defined?(ActiveRecord)
 					column_without_enumerated_attribute(name, type, options)
 				end
 				safe_alias_method_chain :column, :enumerated_attribute
+
+				def change_with_enumerated_attribute(name, type, options = {})
+					type = 'string' if type.to_s == 'enum'
+					change_without_enumerated_attribute(name, type, options)
+				end
+				safe_alias_method_chain :change, :enumerated_attribute
 				
 				def enum(*args)
 					options = args.extract_options!                                      


### PR DESCRIPTION
This allows migrations like:
    def up
      t.change :gear, :enum, :default => 'neutral'
    end
