### PR TITLE
fix: use values returned by attribute setter methods

### DIFF
--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -97,7 +97,7 @@ module EnumeratedAttribute
 								def new(*args, &block)
 									result = new_without_enumerated_attribute(*args, &block)
 									params = (!args.empty? && args.first.instance_of?(Hash)) ? args.first : {}
-                  params.each { |k, v| result.write_enumerated_attribute(k, result[k.to_s]) }
+                  params.each { |k, v| result.write_enumerated_attribute(k, result[k.to_s]) if self.has_enumerated_attribute?(k.to_s) }
 									result.initialize_enumerated_attributes(true)
 									yield result if block_given?
 									result

--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -97,7 +97,7 @@ module EnumeratedAttribute
 								def new(*args, &block)
 									result = new_without_enumerated_attribute(*args, &block)
 									params = (!args.empty? && args.first.instance_of?(Hash)) ? args.first : {}
-									params.each { |k, v| result.write_enumerated_attribute(k, v) }
+                  params.each { |k, v| result.write_enumerated_attribute(k, result[k.to_s]) }
 									result.initialize_enumerated_attributes(true)
 									yield result if block_given?
 									result

--- a/spec/active_record/active_record_spec.rb
+++ b/spec/active_record/active_record_spec.rb
@@ -415,5 +415,10 @@ describe "RaceCar" do
     r =RaceCar.new(:license_plate_number => ' asdf ')
     r.license_plate_number.should == 'asdf'
   end
-	
+
+  it "should not generate Active Record attributes on #new for keys that are not really active record attributes" do
+    r =RaceCar.new(:non_active_record_attribute => 'some value')
+    r.should_not have_attribute(:non_active_record_attribute)
+  end
+
 end

--- a/spec/active_record/active_record_spec.rb
+++ b/spec/active_record/active_record_spec.rb
@@ -409,6 +409,11 @@ describe "RaceCar" do
 		s = RaceCar.find r.id
 		s.lights.should == "--- :off\n"
 		s[:lights].should == "--- :off\n"
-	end
+  end
+
+  it "should use values returned by attribute setter methods" do
+    r =RaceCar.new(:license_plate_number => ' asdf ')
+    r.license_plate_number.should == 'asdf'
+  end
 	
 end

--- a/spec/active_record/race_car.rb
+++ b/spec/active_record/race_car.rb
@@ -2,6 +2,11 @@
 class RaceCar	< ActiveRecord::Base
 	enum_attr :gear, %w(reverse ^neutral first second over_drive)
 	enum_attr :choke, %w(^none medium full)
+
+  def license_plate_number=(value)
+    value = value.strip # remove whitespace from start and end of value
+    write_attribute(:license_plate_number, value)
+  end
 end
 
 #gear = enumerated column attribute

--- a/spec/active_record/race_car.rb
+++ b/spec/active_record/race_car.rb
@@ -3,6 +3,8 @@ class RaceCar	< ActiveRecord::Base
 	enum_attr :gear, %w(reverse ^neutral first second over_drive)
 	enum_attr :choke, %w(^none medium full)
 
+  attr_accessor :non_active_record_attribute
+
   def license_plate_number=(value)
     value = value.strip # remove whitespace from start and end of value
     write_attribute(:license_plate_number, value)

--- a/spec/active_record/test_in_memory.rb
+++ b/spec/active_record/test_in_memory.rb
@@ -12,6 +12,7 @@ ActiveRecord::Base.logger = Logger.new("#{File.dirname(__FILE__)}/active_record.
 connection = ActiveRecord::Base.connection
   connection.create_table(:race_cars, :force=>true) do |t|
 	t.string :name
+	t.string :license_plate_number
 	t.enum :gear
 	t.enum :lights
   t.timestamps


### PR DESCRIPTION
Hi Jeff,

I've discovered extremely annoying bug that is causing active record models to misbehave. If model defines setter methods that change values that are passed, the processed values are reverted back to original values (in new or build assoc methods) by your gem (all logic in setter method is discarded).
For example:

``` ruby
class User
  def email=(value)
    value = value.strip
    write_attribute(:email, value)
  end
end

u = User.new(:email => ' asfd@asdf.com ')
u.email  # will return ' asfd@asdf.com ', but should return 'asfd@asdf.com'
```

Please accept one line fix pull request, which also contains rspec.

Regards,
Alex
