### PR TITLE
Allow using annotate with multiple enumerated_attributes

### DIFF
--- a/lib/enumerated_attribute/integrations/active_record.rb
+++ b/lib/enumerated_attribute/integrations/active_record.rb
@@ -103,7 +103,7 @@ module EnumeratedAttribute
 									result
 								end
 							end
-              unless private_method_defined?(:method_missing_without_enumerated_attribute)
+              unless method_defined?(:method_missing_without_enumerated_attribute) || private_method_defined?(:method_missing_without_enumerated_attribute)
                 define_chained_method(:method_missing, :enumerated_attribute) do |method_id, *arguments|
                   arguments = arguments.map{|arg| arg.is_a?(Symbol) ? arg.to_s : arg }
                   method_missing_without_enumerated_attribute(method_id, *arguments)


### PR DESCRIPTION
Fixes https://github.com/jeffp/enumerated_attribute/issues/56

This is difficult to provide a RSpec test for (I tried), but the fix does work and permits running annotate against models that contain multiple enumerated_attributes.

This fix was inspired by https://github.com/jeffp/meta_programming/blob/master/lib/meta_programming/object.rb#L42
